### PR TITLE
Fix: generate background props for TouchableNativeFeedback

### DIFF
--- a/src/ActionButton/ActionButton.js
+++ b/src/ActionButton/ActionButton.js
@@ -1,15 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  TouchableOpacity,
-  TouchableNativeFeedback,
-  View,
   Platform,
   StyleSheet,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  View,
 } from 'react-native';
-import PropTypes from 'prop-types';
 import Feather from 'react-native-vector-icons/Feather';
-import {useThemeContext} from '../util/ThemeProvider';
 import {shadows, sizes} from '../util/prop-types';
+import {useThemeContext} from '../util/ThemeProvider';
 
 const getContainerStyle = ({theme, size, color, shadow}) => {
   return {
@@ -27,6 +27,7 @@ const ActionButton = React.forwardRef(({style, ...props}, ref) => {
   const theme = useThemeContext();
   const TouchableElement =
     Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
+
   return (
     <TouchableElement {...props} onPress={props.onPress} ref={ref}>
       <View

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,21 +1,22 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  TouchableOpacity,
-  TouchableNativeFeedback,
-  Platform,
-  View,
-  Text,
   Image,
+  Platform,
   StyleSheet,
+  Text,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  View,
 } from 'react-native';
-import PropTypes from 'prop-types';
 import Feather from 'react-native-vector-icons/Feather';
-import {useThemeContext} from '../util/ThemeProvider';
-import {radii, shadows, sizes} from '../util/prop-types';
 import {
   extractAccessibilityPropsFromProps,
   removeAccessibilityPropsFromProps,
 } from '../util/accessibility';
+import {radii, shadows, sizes} from '../util/prop-types';
+import {useThemeContext} from '../util/ThemeProvider';
+import {removeBackgroundProp} from '../util/touchable';
 
 const getContainerStyle = ({
   theme,
@@ -85,6 +86,7 @@ const Avatar = React.forwardRef(({style, ...props}, ref) => {
   const theme = useThemeContext();
   const TouchableElement =
     Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
+  const updateProps = removeBackgroundProp(props);
   return (
     <View
       {...extractAccessibilityPropsFromProps(props)}
@@ -95,7 +97,7 @@ const Avatar = React.forwardRef(({style, ...props}, ref) => {
       ])}>
       <TouchableElement
         disabled={!props.editable}
-        {...removeAccessibilityPropsFromProps(props)}>
+        {...removeAccessibilityPropsFromProps(updateProps)}>
         <View
           style={StyleSheet.flatten([
             getContainerStyle({...props, theme}),

--- a/src/Button/MenuAddButton.js
+++ b/src/Button/MenuAddButton.js
@@ -11,7 +11,7 @@ import {
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import {radii, shadows, sizes} from '../util/prop-types';
 import {useThemeContext, useThemeMode} from '../util/ThemeProvider';
-import { generateTouchableNativeFeedbackBackground } from '../util/touchable';
+import {removeBackgroundProp} from '../util/touchable';
 
 const getContainerStyle = ({
   theme,
@@ -71,14 +71,15 @@ const MenuAddButton = ({style, textStyle, ...props}) => {
   const {isDarkMode} = useThemeMode();
   const TouchableElement =
     Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
-  const background = generateTouchableNativeFeedbackBackground(props, theme);
+
+  const updateProps = removeBackgroundProp(props);
+
   if (props.count < 1) {
     return (
       <TouchableElement
-        {...props}
+        {...updateProps}
         disabled={props.disabled}
-        onPress={props.onIncrement}
-        {...background}>
+        onPress={props.onIncrement}>
         <View style={[getContainerStyle({...props, theme, isDarkMode}), style]}>
           <Text
             style={[getTextStyle({...props, theme, isDarkMode}), textStyle]}>

--- a/src/Button/MenuAddButton.js
+++ b/src/Button/MenuAddButton.js
@@ -1,16 +1,17 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  View,
+  Platform,
+  StyleSheet,
+  Text,
   TouchableNativeFeedback,
   TouchableOpacity,
-  Platform,
-  Text,
-  StyleSheet,
+  View,
 } from 'react-native';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
-import PropTypes from 'prop-types';
-import {useThemeContext, useThemeMode} from '../util/ThemeProvider';
 import {radii, shadows, sizes} from '../util/prop-types';
+import {useThemeContext, useThemeMode} from '../util/ThemeProvider';
+import { generateTouchableNativeFeedbackBackground } from '../util/touchable';
 
 const getContainerStyle = ({
   theme,
@@ -70,12 +71,14 @@ const MenuAddButton = ({style, textStyle, ...props}) => {
   const {isDarkMode} = useThemeMode();
   const TouchableElement =
     Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
+  const background = generateTouchableNativeFeedbackBackground(props, theme);
   if (props.count < 1) {
     return (
       <TouchableElement
         {...props}
         disabled={props.disabled}
-        onPress={props.onIncrement}>
+        onPress={props.onIncrement}
+        {...background}>
         <View style={[getContainerStyle({...props, theme, isDarkMode}), style]}>
           <Text
             style={[getTextStyle({...props, theme, isDarkMode}), textStyle]}>

--- a/src/util/touchable.js
+++ b/src/util/touchable.js
@@ -1,0 +1,25 @@
+import {Platform} from 'react-native';
+
+export const generateTouchableNativeFeedbackBackground = (
+  {background},
+  theme,
+) => {
+  if (!background || Platform.OS === 'ios') {
+    return {};
+  }
+  if (Platform.OS === 'android') {
+    return {
+      background: {
+        borderless: true,
+        type: 'RippleAndroid',
+        color: theme.colors[background],
+      },
+    };
+  }
+};
+
+export const removeBackgroundProp = ({background, ...props}) => {
+  return {
+    ...props,
+  };
+};

--- a/src/util/touchable.js
+++ b/src/util/touchable.js
@@ -1,23 +1,3 @@
-import {Platform} from 'react-native';
-
-export const generateTouchableNativeFeedbackBackground = (
-  {background},
-  theme,
-) => {
-  if (!background || Platform.OS === 'ios') {
-    return {};
-  }
-  if (Platform.OS === 'android') {
-    return {
-      background: {
-        borderless: true,
-        type: 'RippleAndroid',
-        color: theme.colors[background],
-      },
-    };
-  }
-};
-
 export const removeBackgroundProp = ({background, ...props}) => {
   return {
     ...props,


### PR DESCRIPTION
TouchableNativeFeedback is used on android which expects `background` props to be an object. In some cases we pass the whole props object to the TouchableNativeFeedback where `background` maybe just a string and thus crashes the application. 

Fixes this with two functions that either generated the relevant object based on the input string or removes the background from props. 